### PR TITLE
feat(story): add progress check to story creation endpoint

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -341,8 +341,12 @@ func main() {
 		}
 	
 		// Check if the user has an unfinished story
-		progress, err := storyService.GetProgress(uid)
-		if err == nil && progress["story_status"] == "in_progress" {
+ progress := map[string]interface{}{
++    "story_id":               story.ID,
+     "current_sentence_count": count,
+     "max_sentences":          sentencesLeft,
+     "story_status":           story.Status,
+ }
 			c.JSON(http.StatusOK, gin.H{
 				"message":                "You have an unfinished story",
 				"story_id":               progress["story_id"],

--- a/internal/service/story_service.go
+++ b/internal/service/story_service.go
@@ -138,13 +138,24 @@ func (s *storyService) GetProgress(userID uint) (map[string]interface{}, error) 
 	if err != nil {
 		return nil, err
 	}
+	
+	if story.Status == "completed" {
+		return map[string]interface{}{
+			"message": "No active story",
+		}, nil
+	}
+
 	count, err := s.storyRepo.GetSentenceCount(story.ID)
 	if err != nil {
 		return nil, err
 	}
+
+	const maxSentencesAllowed = 5
+	sentencesLeft := maxSentencesAllowed - count
+
 	progress := map[string]interface{}{
 		"current_sentence_count": count,
-		"max_sentences":          5,
+		"max_sentences":          sentencesLeft,
 		"story_status":           story.Status,
 	}
 	return progress, nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new way to begin a story by submitting a title via the `/stories/start_story` endpoint.  
	- If an unfinished story exists, users will now receive clear progress details to continue seamlessly.  
	- Enhanced error messages provide immediate feedback for invalid input or missing user credentials.  
- **Bug Fixes**
	- Improved handling of completed stories to provide accurate user progress information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->